### PR TITLE
Support installation from package.json file

### DIFF
--- a/bin/gpm
+++ b/bin/gpm
@@ -55,16 +55,8 @@ if (destOpt.value) {
 }
 
 if (inputOpt.value === ".") {
-    // Load and parse the package.json file
-    var packageJsonPath = Path.join(process.cwd(), "package.json")
-      , manifest = ReadJson(packageJsonPath)
-      ;
-
-    // Merge all dependencies on a single Array
-    var dependencies = Object.keys(manifest.dependencies)
-      , devDependencies = Object.keys(manifest.devDependencies)
-      ;
-    inputOpt.value = dependencies.concat(devDependencies);
+    // Load a package.json file in the current directory
+    inputOpt.value = ReadJson(Path.join(process.cwd(), "package.json"));
 }
 
 var pack = new Gpm(inputOpt.value, {

--- a/bin/gpm
+++ b/bin/gpm
@@ -9,6 +9,7 @@ var Gpm = require("../lib")
   , Deffy = require("deffy")
   , Ul = require("ul")
   , Path = require("path")
+  , Fs = require("fs")
   ;
 
 // Logger configs
@@ -51,6 +52,17 @@ if (!inputOpt.is_provided) {
 
 if (destOpt.value) {
     destOpt.value = Path.resolve(destOpt.value.replace("~", Ul.home()));
+}
+
+if (inputOpt.value === ".") {
+    // Load and parse the package.json file
+    var packageJsonPath = Path.join(process.cwd(), "package.json")
+      , manifest = JSON.parse(Fs.readFileSync(packageJsonPath));
+
+    // Merge all dependencies on a single Array
+    var dependencies = Object.keys(manifest.dependencies)
+      , devDependencies = Object.keys(manifest.devDependencies);
+    inputOpt.value = dependencies.concat(devDependencies);
 }
 
 var pack = new Gpm(inputOpt.value, {

--- a/bin/gpm
+++ b/bin/gpm
@@ -57,6 +57,7 @@ if (destOpt.value) {
 if (inputOpt.value === ".") {
     // Load a package.json file in the current directory
     inputOpt.value = ReadJson(Path.join(process.cwd(), "package.json"));
+    destOpt.value = destOpt.value || Path.join(process.cwd(), "node_modules");
 }
 
 var pack = new Gpm(inputOpt.value, {

--- a/bin/gpm
+++ b/bin/gpm
@@ -9,7 +9,7 @@ var Gpm = require("../lib")
   , Deffy = require("deffy")
   , Ul = require("ul")
   , Path = require("path")
-  , Fs = require("fs")
+  , ReadJson = require("r-json")
   ;
 
 // Logger configs
@@ -57,11 +57,13 @@ if (destOpt.value) {
 if (inputOpt.value === ".") {
     // Load and parse the package.json file
     var packageJsonPath = Path.join(process.cwd(), "package.json")
-      , manifest = JSON.parse(Fs.readFileSync(packageJsonPath));
+      , manifest = ReadJson(packageJsonPath)
+      ;
 
     // Merge all dependencies on a single Array
     var dependencies = Object.keys(manifest.dependencies)
-      , devDependencies = Object.keys(manifest.devDependencies);
+      , devDependencies = Object.keys(manifest.devDependencies)
+      ;
     inputOpt.value = dependencies.concat(devDependencies);
 }
 

--- a/bin/gpm
+++ b/bin/gpm
@@ -50,14 +50,14 @@ if (!inputOpt.is_provided) {
     return console.log(parser.displayHelp());
 }
 
-if (destOpt.value) {
-    destOpt.value = Path.resolve(destOpt.value.replace("~", Ul.home()));
-}
-
 if (inputOpt.value === ".") {
     // Load a package.json file in the current directory
     inputOpt.value = ReadJson(Path.join(process.cwd(), "package.json"));
-    destOpt.value = destOpt.value || Path.join(process.cwd(), "node_modules");
+    destOpt.value = Deffy(destOpt.value, "node_modules");
+}
+
+if (destOpt.value) {
+    destOpt.value = Path.resolve(destOpt.value.replace("~", Ul.home()));
 }
 
 var pack = new Gpm(inputOpt.value, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,11 +30,11 @@ var el = new ExecLimiter(Deffy(parseInt(process.env.GPM_PROCESS_COUT_LIMIT) || 1
  *
  * @name Gpm
  * @function
- * @param {String} name The git url or the npm package name.
+ * @param {(String|String[])} packages The git url, the npm package name or a list of them.
  * @param {Object} options An object containing the following fields:
  * @return {Gpm} The `Gpm` instance.
  */
-function Gpm(name, options) {
+function Gpm(packages, options) {
 
     options = Ul.merge(options, {
         url_type: "ssh"
@@ -43,19 +43,15 @@ function Gpm(name, options) {
       , is_dev: false
     });
 
+    if (typeof(packages) === "string") {
+      packages = [packages];
+    }
+
+    this.packages = packages;
     this.path = options.dest;
     this.auto = options.auto;
     this.url_type = options.url_type;
-    this.url_parsed = GitUrlParse(name);
     this.is_dev = options.is_dev;
-
-    if (this.url_parsed.protocol !== "file") {
-        this.input = this.url_parsed.toString(options.url_type);
-        this.is_git = true;
-    } else {
-        this.input = name;
-        this.is_git = false;
-    }
 }
 
 /**
@@ -170,15 +166,45 @@ Gpm.prototype.exec = function (command, callback) {
 
 /**
  * install
- * Installs the current package dependencies.
+ * Installs the input packages.
  *
  * @name install
  * @function
  * @param {Function} callback The callback function.
  * @param {Function} progress The progress function.
  */
-Gpm.prototype.install = function (callback, progress) {
+Gpm.prototype.install = function(callback, progress) {
+  var self = this;
+
+  OneByOne(self.packages.map(function(package) {
+    return function(next) {
+      self.name = package;
+      self.installCurrent(next, progress);
+    };
+  }), callback);
+};
+
+/**
+ * installCurrent
+ * Installs the current package dependencies.
+ *
+ * @name installCurrent
+ * @function
+ * @param {Function} callback The callback function.
+ * @param {Function} progress The progress function.
+ */
+Gpm.prototype.installCurrent = function (callback, progress) {
     var self = this;
+
+    self.url_parsed = GitUrlParse(self.name);
+    if (self.url_parsed.protocol !== "file") {
+        self.input = self.url_parsed.toString(self.url_type);
+        self.is_git = true;
+    } else {
+        self.input = self.name;
+        self.is_git = false;
+    }
+
     progress("Installing " + self.input);
     OneByOne([
         self.getPack.bind(self)

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ var el = new ExecLimiter(Deffy(parseInt(process.env.GPM_PROCESS_COUT_LIMIT) || 1
  *
  * @name Gpm
  * @function
- * @param {(String|String[])} packages The git url, the npm package name or a list of them.
+ * @param {String|String[]} packages The git url, the npm package name or a list of them.
  * @param {Object} options An object containing the following fields:
  * @return {Gpm} The `Gpm` instance.
  */
@@ -43,7 +43,7 @@ function Gpm(packages, options) {
       , is_dev: false
     });
 
-    if (typeof(packages) === "string") {
+    if (typeof packages  === "string") {
       packages = [packages];
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,11 +30,11 @@ var el = new ExecLimiter(Deffy(parseInt(process.env.GPM_PROCESS_COUT_LIMIT) || 1
  *
  * @name Gpm
  * @function
- * @param {String|String[]} packages The git url, the npm package name or a list of them.
+ * @param {String|Object} packages The git url, the npm package name or a package.json-like object.
  * @param {Object} options An object containing the following fields:
  * @return {Gpm} The `Gpm` instance.
  */
-function Gpm(packages, options) {
+function Gpm(package, options) {
 
     options = Ul.merge(options, {
         url_type: "ssh"
@@ -43,11 +43,7 @@ function Gpm(packages, options) {
       , is_dev: false
     });
 
-    if (typeof packages  === "string") {
-      packages = [packages];
-    }
-
-    this.packages = packages;
+    this.package = package;
     this.path = options.dest;
     this.auto = options.auto;
     this.url_type = options.url_type;
@@ -165,8 +161,31 @@ Gpm.prototype.exec = function (command, callback) {
 };
 
 /**
+ * getDependencies
+ * Returns the requested dependencies for installation
+ *
+ * @name getDependencies
+ * @function
+ * @return {Array} A list with the dependencies whose installation was required
+ */
+Gpm.prototype.getDependencies = function() {
+  // A single dependency was requested
+  if (typeof this.package === 'string') {
+    return [this.package];
+  }
+
+  // A package.json was requested
+  var dependencies = Object.keys(this.package.dependencies);
+  if (this.is_dev) {
+    dependencies = dependencies.concat(Object.keys(this.package.devDependencies));
+  }
+  return dependencies;
+};
+
+
+/**
  * install
- * Installs the input packages.
+ * Installs the input package(s).
  *
  * @name install
  * @function
@@ -176,7 +195,7 @@ Gpm.prototype.exec = function (command, callback) {
 Gpm.prototype.install = function(callback, progress) {
   var self = this;
 
-  OneByOne(self.packages.map(function(package) {
+  OneByOne(self.getDependencies().map(function(package) {
     return function(next) {
       self.name = package;
       self.installCurrent(next, progress);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "modules"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+  "contributors": [
+    "Nihey Takizawa <nihey.takizawa@gmail.com> (http://nihey.com.br)"
+  ],
   "license": "KINDLY",
   "bugs": {
     "url": "https://github.com/IonicaBizau/node-gpm/issues"


### PR DESCRIPTION
Even though it was suggested modifying `Gpm`'s `pack` on https://github.com/IonicaBizau/node-gpm/issues/2. I thought It could be nice to extend the API to accept packages via string or list.

So I changed `Gpm.prototype.install` function to handle a list of packages, and moved the old `Gpm.prototype.install` to `Gpm.prototype.installCurrent`, the colateral effect of that is moving the url parsing from the `constructor` to the `Gpm.prototype.installCurrent` function. I hope that's alright with you.
