### PR TITLE
nm_dest (node_modules override)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ $ gpm --help
 Usage: gpm [options]
 
 Options:
-  -i, --input <name|git>    The NPM package name or git url.
-  -u, --url-type <type>     The git url type to use (e.g. `https`, `ssh`).
-  -t, --destination <path>  Where to install the package.
-  -d, --depth <depth>       The depth value. Default is Infinity.
-  -h, --help                Displays this help.
-  -v, --version             Displays version information.
+  -i, --input <name|git>                       The NPM package name or git url.              
+  -u, --url-type <type>                        The git url type to use (e.g. `https`, `ssh`).
+  -t, --destination <path>                     Where to install the package.                 
+  -n, --node module destination <folder name>  Name of the  node_module folder.              
+  -d, --depth <depth>                          The depth value. Default is Infinity.         
+  -h, --help                                   Displays this help.                           
+  -v, --version                                Displays version information.                 
 
 Examples:
   gpm -i git-stats # Installs git-stats and its dependencies from git repositories.

--- a/bin/gpm
+++ b/bin/gpm
@@ -29,6 +29,7 @@ Logger.config.done = {
 var inputOpt = new CLP.Option(["i", "input"], "The NPM package name or git url.", "name|git")
   , urlTypeOpt = new CLP.Option(["u", "url-type"], "The git url type to use (e.g. `https`, `ssh`).", "type", "ssh")
   , destOpt = new CLP.Option(["t", "destination"], "Where to install the package.", "path")
+  , nm_destOpt = new CLP.Option(["n", "node module destination"], "Name of the  node_module folder.", "folder name", "node_modules")
   , depthOpt = new CLP.Option(["d", "depth"], "The depth value. Default is Infinity.", "depth")
   , parser = new CLP({
         name: Package.name
@@ -45,6 +46,7 @@ var inputOpt = new CLP.Option(["i", "input"], "The NPM package name or git url."
         inputOpt
       , urlTypeOpt
       , destOpt
+      , nm_destOpt
       , depthOpt
     ])
   ;
@@ -69,6 +71,7 @@ if (destOpt.value) {
 var pack = new Gpm(inputOpt.value, {
     url_type: urlTypeOpt.value
   , dest: Deffy(destOpt.value, undefined, true)
+  , nm_dest: Deffy(nm_destOpt.value, undefined, true)
   , depth: depthOpt.value || Infinity
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,7 @@ class Gpm {
      * @param {Function} callback The callback function.
      */
     runTask (task, callback) {
-        if (typeof this.pack.scripts[task] !== "string" || this.skip) {
+        if (typeof this.pack.scripts[task] !== "string") {
             return callback();
         }
         el.add(oArgv({ _: [task] }, "npm run", true), { cwd: this.repoPath }, callback);
@@ -267,66 +267,62 @@ class Gpm {
                 cb(null, this.repoPath);
             }
           , (cb, path) => {
-                fs.stat(this.repoPath, (err, stat) => {
-                    if (stat && stat.isDirectory()) {
-                        this.skip = true
-                        progress(`Skipping already installed ${this.input}`)
-                    } else {
-                        mkdirp(path, cb);
-                    }
-                })
+                mkdirp(path, cb);
             }
           , this.getGitUrl.bind(this)
           , (cb, gitUrl) => {
-                if (!this.skip) {
-                    progress("Cloning " + gitUrl);
-                    this.repo = new Gry(this.repoPath);
-                    this.repo.exec(oArgv({
-                        _: [gitUrl, "."]
-                    }, "clone", true), cb);
-                } else cb()
+                fs.stat(`${this.repoPath}/.git`, (err, stat) => {
+                    if (stat && stat.isDirectory()) {
+                        progress(`Skipping already installed ${this.input}`)
+                        cb()
+                    } else {
+                        progress("Cloning " + gitUrl);
+                        this.repo = new Gry(this.repoPath);
+                        this.repo.exec(oArgv({
+                            _: [gitUrl, "."]
+                        }, "clone", true), cb);
+                    }
+                })
             }
           , this.runTask.bind(this, "preinstall")
           , cb => {
-                if (!this.skip) {
-                    // And here the recursive-magic is happening
-                    var dep = obj => {
-                            return Object.keys(obj).map(name => {
-                                return cb => {
-                                    if (this.depth === 1) {
-                                        return this.exec(oArgv({
-                                            production: this.is_dev || undefined
-                                          , _: "i"
-                                        }, "npm", true), cb);
-                                    }
+                // And here the recursive-magic is happening
+                var dep = obj => {
+                        return Object.keys(obj).map(name => {
+                            return cb => {
+                                if (this.depth === 1) {
+                                    return this.exec(oArgv({
+                                        production: this.is_dev || undefined
+                                      , _: "i"
+                                    }, "npm", true), cb);
+                                }
 
-                                    var cDep = new Gpm(name, {
-                                        dest: path.resolve(this.repoPath, this.nm_dest)
-                                      , nm_dest: this.nm_dest
-                                      , url_type: this.url_type
-                                      , auto: this.auto
-                                      , is_dev: this.is_dev
-                                      , depth: this.depth - 1
-                                      , version: obj[name]
-                                    });
+                                var cDep = new Gpm(name, {
+                                    dest: path.resolve(this.repoPath, this.nm_dest)
+                                  , nm_dest: this.nm_dest
+                                  , url_type: this.url_type
+                                  , auto: this.auto
+                                  , is_dev: this.is_dev
+                                  , depth: this.depth - 1
+                                  , version: obj[name]
+                                });
 
-                                    cDep.install(cb, progress);
-                                };
-                            });
-                        }
-                      , deps = dep(this.pack.dependencies)
-                      ;
-                    if (this.dev_install) {
-                       deps = deps.concat(dep(this.pack.devDependencies));
+                                cDep.install(cb, progress);
+                            };
+                        });
                     }
+                  , deps = dep(this.pack.dependencies)
+                  ;
+                if (this.dev_install) {
+                   deps = deps.concat(dep(this.pack.devDependencies));
+                }
 
-                    if (!deps.length) {
-                        return cb();
-                    }
+                if (!deps.length) {
+                    return cb();
+                }
 
-                    sameTime(deps, cb);
+                sameTime(deps, cb);
 
-                } else cb()
             }
           , this.runTask.bind(this, "install")
           , this.runTask.bind(this, "postinstall")

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@
 const gitSource = require("git-source")
     , packageJson = require("package-json")
     , ul = require("ul")
+    , fs = require("fs")
     , Gry = require("gry")
     , tmp = require("tmp")
     , oArgv = require("oargv")
@@ -40,6 +41,7 @@ class Gpm {
      *
      *  - `url_type` (String): A value interpreted by `git-url-parse` (default: `"ssh"`).
      *  - `dest` (String): The destination path (defaults to `process.cwd()`).
+     *  - `nm_dest` (String): The node module folder name (defaults to 'node_modules').
      *  - `auto` (Boolean): If `true`, a new directory will be created in the destination directory (default: `true`).
      *  - `is_dev` (Boolean): If `true`, the dev dependencies will be installed as well (default: `false`).
      *  - `depth` (Number): The dependency tree depth (the other dependencies being installed via `npm`). Default is `Infinity`.
@@ -52,6 +54,7 @@ class Gpm {
         options = ul.merge(options, {
             url_type: "ssh"
           , dest: process.cwd()
+          , nm_dest: 'node_modules'
           , auto: true
           , is_dev: false
           , depth: Infinity
@@ -59,6 +62,7 @@ class Gpm {
 
         this.package = packageObj;
         this.path = options.dest;
+        this.nm_dest = options.nm_dest;
         this.auto = options.auto;
         this.url_type = options.url_type;
         this.is_dev = options.is_dev;
@@ -157,7 +161,7 @@ class Gpm {
      * @param {Function} callback The callback function.
      */
     runTask (task, callback) {
-        if (typeof this.pack.scripts[task] !== "string") {
+        if (typeof this.pack.scripts[task] !== "string" || this.skip) {
             return callback();
         }
         el.add(oArgv({ _: [task] }, "npm run", true), { cwd: this.repoPath }, callback);
@@ -263,54 +267,66 @@ class Gpm {
                 cb(null, this.repoPath);
             }
           , (cb, path) => {
-                mkdirp(path, cb);
+                fs.stat(this.repoPath, (err, stat) => {
+                    if (stat && stat.isDirectory()) {
+                        this.skip = true
+                        progress(`Skipping already installed ${this.input}`)
+                    } else {
+                        mkdirp(path, cb);
+                    }
+                })
             }
           , this.getGitUrl.bind(this)
           , (cb, gitUrl) => {
-                progress("Clonning " + gitUrl);
-                this.repo = new Gry(this.repoPath);
-                this.repo.exec(oArgv({
-                    _: [gitUrl, "."]
-                }, "clone", true), cb);
+                if (!this.skip) {
+                    progress("Cloning " + gitUrl);
+                    this.repo = new Gry(this.repoPath);
+                    this.repo.exec(oArgv({
+                        _: [gitUrl, "."]
+                    }, "clone", true), cb);
+                } else cb()
             }
           , this.runTask.bind(this, "preinstall")
           , cb => {
-                // And here the recursive-magic is happening
-                var dep = obj => {
-                        return Object.keys(obj).map(name => {
-                            return cb => {
-                                if (this.depth === 1) {
-                                    return this.exec(oArgv({
-                                        production: this.is_dev || undefined
-                                      , _: "i"
-                                    }, "npm", true), cb);
-                                }
+                if (!this.skip) {
+                    // And here the recursive-magic is happening
+                    var dep = obj => {
+                            return Object.keys(obj).map(name => {
+                                return cb => {
+                                    if (this.depth === 1) {
+                                        return this.exec(oArgv({
+                                            production: this.is_dev || undefined
+                                          , _: "i"
+                                        }, "npm", true), cb);
+                                    }
 
-                                var cDep = new Gpm(name, {
-                                    dest: path.join(this.repoPath, "node_modules")
-                                  , url_type: this.url_type
-                                  , auto: this.auto
-                                  , is_dev: this.is_dev
-                                  , depth: this.depth - 1
-                                  , version: obj[name]
-                                });
+                                    var cDep = new Gpm(name, {
+                                        dest: path.resolve(this.repoPath, this.nm_dest)
+                                      , nm_dest: this.nm_dest
+                                      , url_type: this.url_type
+                                      , auto: this.auto
+                                      , is_dev: this.is_dev
+                                      , depth: this.depth - 1
+                                      , version: obj[name]
+                                    });
 
-                                cDep.install(cb, progress);
-                            };
-                        });
+                                    cDep.install(cb, progress);
+                                };
+                            });
+                        }
+                      , deps = dep(this.pack.dependencies)
+                      ;
+                    if (this.dev_install) {
+                       deps = deps.concat(dep(this.pack.devDependencies));
                     }
-                  , deps = dep(this.pack.dependencies)
-                  ;
 
-                if (this.dev_install) {
-                    deps = deps.concat(dep(this.pack.devDependencies));
-                }
+                    if (!deps.length) {
+                        return cb();
+                    }
 
-                if (!deps.length) {
-                    return cb();
-                }
+                    sameTime(deps, cb);
 
-                sameTime(deps, cb);
+                } else cb()
             }
           , this.runTask.bind(this, "install")
           , this.runTask.bind(this, "postinstall")


### PR DESCRIPTION
I added an option to override the 'node_modules' directory name, i.e. with '.' or '..'. This is at least a partial solution for #16, but does not go the extra step of linking the result to a 'node_modules' folder in the project root directory. My reasoning for this is because the symbolic links are not guaranteed to work (i.e. if relative links exist inside), and also because that is not my goal. My goal is to make it easier to distribute isomorphic code using git and not npm/node_modules at all.