### PR TITLE
check NODE_ENV and default to dev mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ class Gpm {
           , dest: process.cwd()
           , nm_dest: 'node_modules'
           , auto: true
-          , is_dev: false
+          , is_dev: process.env.NODE_ENV === 'production' ? false : true
           , depth: Infinity
         });
 


### PR DESCRIPTION
The npm version of install command defaults to including devDependencies. This update first checks for NODE_ENV equal to "production" then defaults to is_dev true, just like npm i.